### PR TITLE
Add total and totalpages headers.

### DIFF
--- a/php/RestController.php
+++ b/php/RestController.php
@@ -170,8 +170,8 @@ class RestController extends WP_REST_Controller {
 		$max_pages   = 0;
 
 		try {
-			$api_response = Search::photos( $search, $page, $per_page, $orientation, $collections );
-			$results      = $api_response->getArrayObject()->toArray();
+			$api_response = Search::photos( $search, $page, $per_page, $orientation, $collections )->getArrayObject();
+			$results      = $api_response->toArray();
 			$max_pages    = $api_response->totalPages();
 			$total        = $api_response->totalObjects();
 			foreach ( $results as $photo ) {


### PR DESCRIPTION
WordPress core supports passing HEADERS in API responses. See this [example](https://github.com/WordPress/WordPress/blob/b7634470193acd081d8de0b43ddf279c1158c378/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L350-L351).

The PHP SDK  passing [Total pages](https://github.com/unsplash/unsplash-php/blob/4cc5f5f8eff3dc33403fea5e90b6f60c85c963e2/src/ArrayObject.php#L63-L69) and [Total Objects](https://github.com/unsplash/unsplash-php/blob/4cc5f5f8eff3dc33403fea5e90b6f60c85c963e2/src/ArrayObject.php#L76-L84) ( Photos ). This PR, just passing them through. 