### PR TITLE
Load only stable dependencies 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.0",
-    "dealerdirect/phpcodesniffer-composer-installer": "*",
+    "dealerdirect/phpcodesniffer-composer-installer": "@stable",
     "php-coveralls/php-coveralls": "2.2.0",
-    "phpcompatibility/phpcompatibility-wp": "*",
+    "phpcompatibility/phpcompatibility-wp": "@stable",
     "phpunit/phpcov": "^3.1",
     "phpunit/phpunit": "^5.7",
     "sirbrillig/phpcs-variable-analysis": "^2.8",
-    "slowprog/composer-copy-file": "*",
+    "slowprog/composer-copy-file": "@stable",
     "wp-api/basic-auth": "dev-master",
-    "wp-coding-standards/wpcs": "^2.2",
+    "wp-coding-standards/wpcs": "@stable",
     "wpackagist-plugin/classic-editor": "@stable",
-    "xwp/wordpress-tests-installer": "*",
-    "xwp/wp-dev-lib": "*"
+    "xwp/wordpress-tests-installer": "@stable",
+    "xwp/wp-dev-lib": "@stable"
   },
   "scripts": {
     "build": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a53d7fc1890c8ebf2f682f435748feb0",
+    "content-hash": "407702b852fe54a53676f2bda30d32e1",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -3263,8 +3263,14 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "dealerdirect/phpcodesniffer-composer-installer": 0,
+        "phpcompatibility/phpcompatibility-wp": 0,
+        "slowprog/composer-copy-file": 0,
         "wp-api/basic-auth": 20,
-        "wpackagist-plugin/classic-editor": 0
+        "wp-coding-standards/wpcs": 0,
+        "wpackagist-plugin/classic-editor": 0,
+        "xwp/wordpress-tests-installer": 0,
+        "xwp/wp-dev-lib": 0
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Loading from `*` in composer can be dangerous. This normally resolves to master branch. Depending on the project, master may not be seen as stable. The `@stable` keyword locks composer to only stable tagged releases.