### PR TITLE
Use xenial instead of trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 
 language: php
 
-dist: trusty
+dist: xenial
 
 services:
   - mysql


### PR DESCRIPTION
Use xenial instead of trusty for travis tests. It xenial has chrome pre-installed in the image., which makes the E2E run faster, as they do not need to download chrome.