### PR TITLE
Do not load unsplash, if user can not upload media

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -73,6 +73,9 @@ class Plugin extends Plugin_Base {
 	 * @action wp_enqueue_media
 	 */
 	public function enqueue_media_scripts() {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return false;
+		}
 		$screen = ( function_exists( 'get_current_screen' ) ) ? get_current_screen() : false;
 
 		if ( ! $screen instanceof WP_Screen ) {

--- a/tests/phpunit/php/class-test-plugin.php
+++ b/tests/phpunit/php/class-test-plugin.php
@@ -15,6 +15,35 @@ namespace Unsplash;
 class Test_Plugin extends \WP_UnitTestCase {
 
 	/**
+	 * Admin user for test.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user for test.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id      = $factory->user->create(
+			[ 'role' => 'administrator' ]
+		);
+		self::$subscriber_id = $factory->user->create(
+			[ 'role' => 'subscriber' ]
+		);
+	}
+
+	/**
 	 * Test constructor.
 	 *
 	 * @see Plugin::__construct()
@@ -47,6 +76,7 @@ class Test_Plugin extends \WP_UnitTestCase {
 	 * @see Plugin::enqueue_media_scripts()
 	 */
 	public function test_enqueue_media_scripts() {
+		wp_set_current_user( self::$admin_id );
 		set_current_screen( 'post.php' );
 		$plugin = get_plugin_instance();
 		$plugin->enqueue_media_scripts();
@@ -59,10 +89,24 @@ class Test_Plugin extends \WP_UnitTestCase {
 	 * @see Plugin::enqueue_media_scripts()
 	 */
 	public function test_no_enqueue_media_scripts() {
+		wp_set_current_user( self::$admin_id );
 		set_current_screen( 'widget.php' );
 		$plugin = get_plugin_instance();
 		$this->assertFalse( $plugin->enqueue_media_scripts() );
 	}
+
+	/**
+	 * Test for enqueue_media_scripts() method doeesn't load on widget
+	 *
+	 * @see Plugin::enqueue_media_scripts()
+	 */
+	public function test_not_logged_enqueue_media_scripts() {
+		wp_set_current_user( self::$subscriber_id );
+		set_current_screen( 'post.php' );
+		$plugin = get_plugin_instance();
+		$this->assertFalse( $plugin->enqueue_media_scripts() );
+	}
+
 
 	/**
 	 * Test for enqueue_media_scripts() method doeesn't load on random screen
@@ -70,6 +114,7 @@ class Test_Plugin extends \WP_UnitTestCase {
 	 * @see Plugin::enqueue_media_scripts()
 	 */
 	public function test_no_random_enqueue_media_scripts() {
+		wp_set_current_user( self::$admin_id );
 		set_current_screen( 'unsplash.php' );
 		$plugin = get_plugin_instance();
 		$this->assertFalse( $plugin->enqueue_media_scripts() );


### PR DESCRIPTION
## Summary

Do not load unsplash JS if user can not upload images. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
