### PR TITLE
Force images to load before the view is rendered

### DIFF
--- a/assets/src/media-selector/helpers/preloadImage.js
+++ b/assets/src/media-selector/helpers/preloadImage.js
@@ -1,0 +1,17 @@
+/**
+ * Preload image using a promise.
+ *
+ * @param {string} src Image source.
+ * @return {Promise} Image object.
+ */
+const preloadImage = src => {
+	return new Promise( ( resolve, reject ) => {
+		const image = new window.Image();
+		image.onload = () => resolve( image );
+		image.onerror = reject;
+		image.decoding = 'async';
+		image.src = src;
+	} );
+};
+
+export default preloadImage;

--- a/assets/src/media-selector/models/images_query_model.js
+++ b/assets/src/media-selector/models/images_query_model.js
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import ImagesCollection from '../collections/images_collection';
 import getConfig from '../helpers/getConfig';
+import preloadImage from '../helpers/preloadImage';
 
 const ImagesQueryModel = wp.media.model.Query.extend(
 	{
@@ -118,6 +119,13 @@ const ImagesQueryModel = wp.media.model.Query.extend(
 					query._respSuccess = resp.success;
 					const error = resp.data.shift();
 					this._respErrorMessage = error;
+				} else if ( resp.length ) {
+					// Force images to load before the view is rendered.
+					resp.forEach( ( { sizes } ) => {
+						if ( sizes && sizes.medium && sizes.medium.url ) {
+							preloadImage( sizes.medium.url );
+						}
+					} );
 				}
 			} ) );
 		},


### PR DESCRIPTION
## Summary

This is an add-on for #66 

This is something I wanted to do for a while. As this helps #66 thought I would add it. 

This PR is simple, create an hidden image element for each image before it is rendered, so force the browser to start downloading. This way, images should come in faster. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
