### PR TITLE
Update method of determining Unsplash attachment

### DIFF
--- a/assets/src/media-selector/helpers/importImages.js
+++ b/assets/src/media-selector/helpers/importImages.js
@@ -26,8 +26,8 @@ export default selections => {
  * @return {Promise} Promise.
  */
 const importImage = image => {
-	const { unsplashId } = image.attributes;
-	const importUrl = getConfig( 'route' ) + `/import/${ unsplashId }`;
+	const { id } = image.attributes;
+	const importUrl = getConfig( 'route' ) + `/import/${ id }`;
 	const processUrl = getConfig( 'route' ) + `/post-process/`;
 
 	return apiFetch( { url: importUrl } )

--- a/assets/src/media-selector/helpers/isUnsplashImage.js
+++ b/assets/src/media-selector/helpers/isUnsplashImage.js
@@ -6,6 +6,6 @@
  */
 export default attachment => {
 	return (
-		attachment.attributes && undefined !== attachment.attributes.unsplashId
+		attachment.attributes && undefined !== attachment.attributes.unsplash_order
 	);
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes:

- How an Unsplash attachment is determined
- Retrieving the Unsplash ID for importing.

Related: https://github.com/xwp/unsplash-wp/pull/72. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
