### PR TITLE
Add back unsplashid into ajax response

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -147,6 +147,7 @@ class Plugin extends Plugin_Base {
 
 		$response = [
 			'id'             => isset( $photo['id'] ) ? $photo['id'] : null,
+			'unsplashId'     => isset( $photo['unsplash_id'] ) ? $photo['unsplash_id'] : null,
 			'unsplash_order' => isset( $photo['unsplash_order'] ) ? $photo['unsplash_order'] : null,
 			'title'          => '',
 			'filename'       => $image->get_field( 'file' ),

--- a/php/class-rest-controller.php
+++ b/php/class-rest-controller.php
@@ -793,7 +793,7 @@ class Rest_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Set a unique ID on the photo so that it does not clash with other media objects in the media library.
+	 * Add order field and set unsplash ID.
 	 *
 	 * @param array $photo    Photo attributes.
 	 * @param int   $index    Index of $photo in current page.
@@ -802,14 +802,8 @@ class Rest_Controller extends WP_REST_Controller {
 	 * @return array Photo with updated ID.
 	 */
 	public function set_unique_media_id( $photo, $index, $page, $per_page ) {
-		/*
-		 * The media selector uses the image ID to sort the list of images received from the API, so an
-		 * incremental ID is generated and set on the photo so that they can be ordered correctly.
-		 *
-		 * The 'unsplash-' prefix is added to prevent any attachment ID collisions in the media selector and
-		 * will be stripped when media objects are being compared.
-		 */
 		$photo['unsplash_order'] = ( $index + ( ( $page - 1 ) * $per_page ) );
+		$photo['unsplash_id']    = $photo['id'];
 
 		return $photo;
 	}

--- a/tests/phpunit/php/class-test-rest-controller.php
+++ b/tests/phpunit/php/class-test-rest-controller.php
@@ -130,6 +130,7 @@ class Test_Rest_Controller extends WP_Test_REST_Controller_Testcase {
 		foreach ( $data as $photo_object ) {
 			$expected_keys = [
 				'id',
+				'unsplashId',
 				'unsplash_order',
 				'title',
 				'filename',
@@ -269,6 +270,7 @@ class Test_Rest_Controller extends WP_Test_REST_Controller_Testcase {
 				],
 			],
 			'unsplash_order' => 0,
+			'unsplashId'     => 'rO8TdlRrOo0',
 		];
 
 		if ( version_compare( '5.2', get_bloginfo( 'version' ), '<' ) ) {


### PR DESCRIPTION
## Summary

Add back unsplash id, as without it, images to do not import

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
