### PR TITLE
Set background color for image

### DIFF
--- a/assets/src/media-selector/views/image_view.js
+++ b/assets/src/media-selector/views/image_view.js
@@ -59,6 +59,7 @@ const ImageView = wp.media.view.Attachment.extend( {
 		if ( 1 === img.length ) {
 			img[ 0 ].width = options.size.width;
 			img[ 0 ].height = options.size.height;
+			img[ 0 ].style.backgroundColor = options.color;
 		}
 
 		this.$el.toggleClass( 'uploading', options.uploading );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -156,6 +156,7 @@ class Plugin extends Plugin_Base {
 			'author'         => $image->get_field( 'user' )['name'],
 			'description'    => $image->get_field( 'description' ),
 			'caption'        => $image->get_caption(),
+			'color'          => $image->get_field( 'color' ),
 			'name'           => $image->get_field( 'original_id' ),
 			'height'         => $image->get_field( 'height' ),
 			'width'          => $image->get_field( 'width' ),

--- a/tests/phpunit/php/class-test-rest-controller.php
+++ b/tests/phpunit/php/class-test-rest-controller.php
@@ -139,6 +139,7 @@ class Test_Rest_Controller extends WP_Test_REST_Controller_Testcase {
 				'author',
 				'description',
 				'caption',
+				'color',
 				'name',
 				'height',
 				'width',
@@ -269,6 +270,7 @@ class Test_Rest_Controller extends WP_Test_REST_Controller_Testcase {
 				],
 			],
 			'unsplash_order' => 0,
+			'color'          => '#F6F7FB',
 		];
 
 		if ( version_compare( '5.2', get_bloginfo( 'version' ), '<' ) ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Adds a background color to the image to fill the initial blank white space.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
