### PR TITLE
Use add query var

### DIFF
--- a/php/class-rest-controller.php
+++ b/php/class-rest-controller.php
@@ -305,7 +305,7 @@ class Rest_Controller extends WP_REST_Controller {
 			$response = $this->prepare_item_for_response( $results, $request );
 			$response = $this->rest_ensure_response( $response, $request );
 			$response->set_status( 301 );
-			$response->header( 'Location', rest_url( sprintf( '%s/%s/%d?context=edit', 'wp/v2', 'media', $attachment_id ) ) );
+			$response->header( 'Location', add_query_arg( 'context', 'edit', rest_url( sprintf( '%s/%s/%d', 'wp/v2', 'media', $attachment_id ) ) ) );
 		} catch ( \Exception $e ) {
 			$response = $this->format_exception( 'single-photo-download', $e->getCode() );
 			$this->plugin->log_error( $e );


### PR DESCRIPTION
## Summary

When a permalink structure is not setup, ?context=edit did not work. Using add query var fixes this.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
