### PR TITLE
Always allow image details to be edited

### DIFF
--- a/assets/src/media-selector/helpers/withUnsplashTab.js
+++ b/assets/src/media-selector/helpers/withUnsplashTab.js
@@ -64,13 +64,6 @@ export default View => {
 			// TODO - Load selection from the correct state.
 			const ogState = this.state();
 
-			/*
-			 * By default, only the 'insert' library (Media Library) allows for attachment details to be edited.
-			 * Setting `allowLocalEdits` on the state allows for the details to be edited irregardless of the original
-			 * media library being overridden.
-			 */
-			ogState.attributes.allowLocalEdits = true;
-
 			contentRegion.view = new ImagesBrowser( {
 				controller: this,
 				AttachmentView: ImageView,

--- a/assets/src/media-selector/views/images_browser.js
+++ b/assets/src/media-selector/views/images_browser.js
@@ -69,6 +69,27 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 			} )
 		);
 	},
+
+	createSingle() {
+		wp.media.view.AttachmentsBrowser.prototype.createSingle.apply(
+			this,
+			arguments
+		);
+
+		const sidebar = this.sidebar,
+			single = this.options.selection.single();
+
+		sidebar.set(
+			'details',
+			new wp.media.view.Attachment.Details( {
+				controller: this.controller,
+				model: single,
+				priority: 80,
+				allowLocalEdits: true,
+			} )
+		);
+	},
+
 	createAttachments() {
 		const noResults = getConfig( 'noResults' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes UVP-74.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
