### PR TITLE
Update masonry layout on model deletion

### DIFF
--- a/assets/src/media-selector/views/images_browser.js
+++ b/assets/src/media-selector/views/images_browser.js
@@ -13,7 +13,7 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 		this.collection.on( 'add remove reset', this.focusInput, this );
 
 		// Update masonry layout only when a set of images (new page) is loaded.
-		this.collection.on( 'attachments:received', () =>
+		this.collection.on( 'attachments:received remove', () =>
 			this.attachments.recalculateLayout()
 		);
 		this.collection.on(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes issue with masonry layout not re-rendering when a model is removed.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
