### PR TITLE
Show error if post-process failed

### DIFF
--- a/assets/src/media-selector/helpers/isBlockEditor.js
+++ b/assets/src/media-selector/helpers/isBlockEditor.js
@@ -1,0 +1,3 @@
+export default () => {
+	return !! window.wp.blockEditor;
+};

--- a/assets/src/media-selector/views/images_browser.js
+++ b/assets/src/media-selector/views/images_browser.js
@@ -91,7 +91,7 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 	},
 
 	createAttachments() {
-		const noResults = getConfig( 'noResults' );
+		const errorMessages = getConfig( 'errorMessages' );
 
 		this.attachments = new ImageViews( {
 			controller: this.controller,
@@ -125,7 +125,9 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 		} );
 
 		this.attachmentsNoResults.$el.addClass( 'hidden no-media' );
-		this.attachmentsNoResults.$el.append( `<h2>${ noResults.noMedia }</h2>` );
+		this.attachmentsNoResults.$el.append(
+			`<h2>${ errorMessages.noMedia }</h2>`
+		);
 
 		this.views.add( this.attachmentsNoResults );
 

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -158,9 +158,9 @@ class Plugin extends Plugin_Base {
 			'unsplash-media-selector',
 			'unsplash',
 			[
-				'tabTitle'  => __( 'Unsplash', 'unsplash' ),
-				'route'     => rest_url( 'unsplash/v1/photos' ),
-				'toolbar'   => [
+				'tabTitle'      => __( 'Unsplash', 'unsplash' ),
+				'route'         => rest_url( 'unsplash/v1/photos' ),
+				'toolbar'       => [
 					'filters' => [
 						'search' => [
 							'label'       => __( 'Search', 'unsplash' ),
@@ -168,10 +168,10 @@ class Plugin extends Plugin_Base {
 						],
 					],
 				],
-				'noResults' => [
-					'noMedia' => __( 'No items found.', 'unsplash' ),
+				'errorMessages' => [
+					'postProcess' => __( 'Post-processing of the Unsplash image "<%- filename %>" failed. This was likely because the server is busy or does not have enough resources. Selecting Unsplash images one at a time may help.', 'unsplash' ),
+					'noMedia'     => __( 'No items found.', 'unsplash' ),
 				],
-
 			]
 		);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Displays a notice in the classic and block editor when post-processing for an image fails.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
