### PR TITLE
Fix double import issue

### DIFF
--- a/assets/src/media-selector/helpers/isUnsplashImage.js
+++ b/assets/src/media-selector/helpers/isUnsplashImage.js
@@ -6,6 +6,8 @@
  */
 export default attachment => {
 	return (
-		attachment.attributes && undefined !== attachment.attributes.unsplash_order && typeof attachment.attributes.id === 'string'
+		attachment.attributes &&
+		undefined !== attachment.attributes.unsplash_order &&
+		typeof attachment.attributes.id === 'string'
 	);
 };


### PR DESCRIPTION
## Summary

Fix issue where an image that had been imported before, could not be inserted again.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
