### PR TITLE
Focus search input on modal open and when the tab is activated

### DIFF
--- a/assets/src/media-selector/views/images_browser.js
+++ b/assets/src/media-selector/views/images_browser.js
@@ -10,7 +10,11 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 			arguments
 		);
 
-		this.collection.on( 'add remove reset', this.focusInput, this );
+		this.controller.on(
+			'open content:activate:unsplash',
+			this.focusInput,
+			this
+		);
 
 		// Update masonry layout only when a set of images (new page) is loaded.
 		this.collection.on( 'attachments:received remove', () =>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes UVP-170.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
