### PR TITLE
Trigger download correctly.

### DIFF
--- a/php/class-api.php
+++ b/php/class-api.php
@@ -32,27 +32,39 @@ class API {
 	}
 
 	/**
-	/**
 	 * Retrieve the a photo object from the ID specified.
 	 *
 	 * @param string $id ID of the photo.
-	 * @param bool   $trigger_download If a request is fired to count a download.
 	 *
 	 * @return array|Api_Response|WP_Error
 	 */
-	public function get( $id, $trigger_download = false ) {
+	public function get( $id ) {
 		$request = $this->send_request( "/photos/{$id}", [] );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;
 		}
 
-		if ( $trigger_download ) {
-			// Make a remote, uncached and unblocking call to the download endpoint.
-			$this->get_remote( $request['body']['links']['download_location'], [ 'blocking' => false ] );
-		}
 		return new Api_Response( $request['body'], 1, 1, $request['cached'] );
 	}
+
+	/**
+	 * Retrieve the a photo object from the ID specified.
+	 *
+	 * @param string $id ID of the photo.
+	 *
+	 * @return array|Api_Response|WP_Error
+	 */
+	public function download( $id ) {
+		$request = $this->send_request( "/photos/{$id}/download", [ 'cb' => microtime() ] );
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		return new Api_Response( $request['body'], 1, 1, $request['cached'] );
+	}
+
+
 
 	/**
 	 * Retrieve all the photos on a specific page.

--- a/php/class-rest-controller.php
+++ b/php/class-rest-controller.php
@@ -230,11 +230,10 @@ class Rest_Controller extends WP_REST_Controller {
 	public function get_import( $request ) {
 		$id = $request->get_param( 'id' );
 
-		$api_response = $this->api->get( $id, true );
+		$api_response = $this->api->get( $id );
 		if ( is_wp_error( $api_response ) ) {
 			return $this->rest_ensure_response( $api_response, $request );
 		}
-
 		$results       = $api_response->get_results();
 		$credentials   = $this->plugin->settings->get_credentials();
 		$utm_source    = $credentials['utmSource'];
@@ -244,7 +243,7 @@ class Rest_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $attachment_id ) ) {
 			return $this->rest_ensure_response( $attachment_id, $request );
 		}
-
+		$this->api->download( $id );
 		$response = $this->prepare_item_for_response( $results, $request );
 		$response = rest_ensure_response( $response );
 		$response->set_status( 301 );

--- a/tests/phpunit/php/class-test-rest-controller.php
+++ b/tests/phpunit/php/class-test-rest-controller.php
@@ -396,6 +396,8 @@ class Test_Rest_Controller extends WP_Test_REST_Controller_Testcase {
 	 * Test get_download().
 	 *
 	 * @covers \Unsplash\Rest_Controller::get_import()
+	 * @covers \Unsplash\API::get()
+	 * @covers \Unsplash\API::download()
 	 */
 	public function test_get_import() {
 		wp_set_current_user( self::$admin_id );


### PR DESCRIPTION
## Summary

When triggering the download, make sure if passing the Client ID to the request, otherwise the API will reject it. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
