### PR TITLE
Fix for masorny not load pre WP 5.3

### DIFF
--- a/assets/src/media-selector/collections/images-collection.js
+++ b/assets/src/media-selector/collections/images-collection.js
@@ -20,6 +20,60 @@ const ImagesCollection = wp.media.model.Attachments.extend( {
 	},
 
 	/**
+	 * This method has been back ported from WordPress 5.3 because of the attachments:received trigger.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/blob/d05f0a86b23e37b9d97acd9317ff3fd661d64dea/src/js/media/models/attachments.js#L276-L299
+	 *
+	 * @param {wp.media.model.Attachments} attachments The attachments collection to mirror.
+	 * @return {wp.media.model.Attachments} Returns itself to allow chaining
+	 */
+	mirror( attachments ) {
+		if ( this.mirroring && this.mirroring === attachments ) {
+			return this;
+		}
+		this.unmirror();
+		this.mirroring = attachments;
+		// Clear the collection silently. A `reset` event will be fired
+		// when `observe()` calls `validateAll()`.
+		this.reset( [], { silent: true } );
+		this.observe( attachments );
+
+		// Used for the search results and unsplash view.
+		this.trigger( 'attachments:received', this );
+		return this;
+	},
+	/**
+	 * This method has been back ported from WordPress 5.3 because of the attachments:received trigger.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/blob/d05f0a86b23e37b9d97acd9317ff3fd661d64dea/src/js/media/models/attachments.js#L311-L343
+	 *
+	 * @param   {Object}  [options={}]
+	 * @return {Promise} Return promise object.
+	 */
+	more( options ) {
+		const deferred = jQuery.Deferred();
+		const mirroring = this.mirroring;
+		const attachments = this;
+
+		if ( ! mirroring || ! mirroring.more ) {
+			return deferred.resolveWith( this ).promise();
+		}
+		// If we're mirroring another collection, forward `more` to
+		// the mirrored collection. Account for a race condition by
+		// checking if we're still mirroring that collection when
+		// the request resolves.
+		mirroring.more( options ).done( () => {
+			if ( this === attachments.mirroring ) {
+				deferred.resolveWith( this );
+			}
+
+			// Used for the search results and unsplash view.
+			attachments.trigger( 'attachments:received', this );
+		} );
+
+		return deferred.promise();
+	},
+	/**
 	 * Get value of respSuccess from mirrored object.
 	 *
 	 * @return {boolean} True / false, response sucesss.

--- a/assets/src/media-selector/views/images-browser.js
+++ b/assets/src/media-selector/views/images-browser.js
@@ -23,6 +23,7 @@ const ImagesBrowser = wp.media.view.AttachmentsBrowser.extend( {
 		this.collection.on( 'attachments:received remove', () =>
 			this.attachments.recalculateLayout()
 		);
+
 		this.collection.on(
 			'add remove reset attachments:received',
 			this.showError,


### PR DESCRIPTION
## Summary
In UVP-178 it was noted that the the masonry view ( using the macy library ) is not loading loading. Looking into the issue more, it seems like the masonry was loading on site running WordPress 5.3 and above. This is because the our code uses a trigger ( backbone event / hook ), to trigger redraw of the masonry called `attachments:received`. The trigger was only added in 5.3. 

In this PR, I simply back port two method that implement this trigger. 

Fixes UVP-178

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
