### PR TITLE
Styling issue for media selector message.

### DIFF
--- a/assets/src/media-selector/style.css
+++ b/assets/src/media-selector/style.css
@@ -81,6 +81,8 @@
 .media-frame .unsplash-browser .unsplash-error {
 	padding: 15px 20px;
 	font-size: 1.4em;
+	line-height: 1.75;
+	margin: 0 15px 0 0;
 	top: 20px;
 }
 
@@ -99,7 +101,10 @@
 
 @media only screen and (max-width: 900px) {
 
-	.media-frame .unsplash-browser .unsplash-error,
+	.media-frame .unsplash-browser .unsplash-error {
+		right: 282px;
+	}
+
 	.media-frame .unsplash-browser .no-media,
 	.media-frame .unsplash-browser .attachments {
 		right: 262px;
@@ -109,7 +114,10 @@
 
 @media only screen and (max-width: 640px), screen and (max-height: 400px) {
 
-	.media-frame .unsplash-browser .unsplash-error,
+	.media-frame .unsplash-browser .unsplash-error {
+		right: 20px;
+	}
+
 	.media-frame .unsplash-browser .no-media,
 	.media-frame .unsplash-browser .attachments {
 		right: 0;


### PR DESCRIPTION
## Summary

Before. 
While testing I noticed some styling issues with the message in the media selector. 
![Screenshot 2020-05-19 at 17 48 10](https://user-images.githubusercontent.com/237508/82354674-0780a800-99f9-11ea-9444-2320571a051d.png)
![Screenshot 2020-05-19 at 17 47 49](https://user-images.githubusercontent.com/237508/82354678-08b1d500-99f9-11ea-8eb2-d619b12a2e9f.png)
![Screenshot 2020-05-19 at 17 47 40](https://user-images.githubusercontent.com/237508/82354680-094a6b80-99f9-11ea-8415-473fc6e2aeac.png)
![Screenshot 2020-05-19 at 17 47 28](https://user-images.githubusercontent.com/237508/82354685-09e30200-99f9-11ea-98ad-4bfe4152ea8f.png)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
