### PR TITLE
Ignore files in js coverage

### DIFF
--- a/assets/src/admin/index.js
+++ b/assets/src/admin/index.js
@@ -1,5 +1,5 @@
+/* istanbul ignore file */
 /**
  * Internal dependencies
  */
 import './style.css';
-/* istanbul ignore file */

--- a/assets/src/polyfills/wp-i18n.js
+++ b/assets/src/polyfills/wp-i18n.js
@@ -1,8 +1,9 @@
+/* istanbul ignore file */
 /**
  * WordPress dependencies
  */
 import * as i18n from '@wordpress/i18n';
-/* istanbul ignore file */
+
 window.wp = window.wp || {};
 
 window.wp.i18n = i18n;

--- a/assets/src/polyfills/wp-polyfill.js
+++ b/assets/src/polyfills/wp-polyfill.js
@@ -1,6 +1,7 @@
+/* istanbul ignore file */
 /**
  * External dependencies
  */
 import * as polyfill from '@babel/polyfill';
-/* istanbul ignore file */
+
 export default polyfill;

--- a/assets/src/polyfills/wp-url.js
+++ b/assets/src/polyfills/wp-url.js
@@ -1,8 +1,9 @@
+/* istanbul ignore file */
 /**
  * WordPress dependencies
  */
 import * as url from '@wordpress/url';
-/* istanbul ignore file */
+
 window.wp = window.wp || {};
 
 window.wp.url = url;


### PR DESCRIPTION
## Summary
Remove polyfill and admin bootstrap file from code coverage. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
