### PR TITLE
Ignore phpcs-js.xml

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = function( grunt ) {
 					'!package.json',
 					'!package-lock.json',
 					'!phpcs.xml',
+					'!phpcs-js.xml',
 					'!phpunit.xml',
 					'!postcss.config.js',
 					'!readme.md',


### PR DESCRIPTION
## Summary

Ignore phpcs-js.xml on build.
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
