### PR TITLE
Add block support.

### DIFF
--- a/assets/src/block-editor/blocks/image/block.json
+++ b/assets/src/block-editor/blocks/image/block.json
@@ -1,5 +1,6 @@
 {
   "name": "unsplash/image",
+  "title": "Unsplash",
   "category": "common",
   "supports": {
     "lightBlockWrapper": true,

--- a/php/class-block-type.php
+++ b/php/class-block-type.php
@@ -40,6 +40,10 @@ class Block_Type {
 	 * @action init
 	 */
 	public function register_blocks() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
 		$blocks_dir    = $this->plugin->dir_path . '/assets/js/blocks/';
 		$block_folders = [
 			'image',
@@ -64,9 +68,7 @@ class Block_Type {
 				$metadata['render_callback'] = [ $this, $callback ];
 			}
 
-			if ( function_exists( '\register_block_type' ) ) {
-				\register_block_type( $metadata['name'], $metadata );
-			}
+			register_block_type( $metadata['name'], $metadata );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Unsplash ===
 Contributors: unsplash, xwp
-Tags: unsplash, images, media, free, photographs, photos
+Tags: unsplash, images, media, free, photographs, photos, block
 Requires at least: 4.9
 Stable tag: 1.0.0
 Tested up to: 5.4.2


### PR DESCRIPTION
## Summary

Small tweaks to make this plugin surface as block compatibility. This will show the plugin here - https://en-gb.wordpress.org/plugins/browse/blocks/

Fixes #196

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
