### PR TITLE
Fix issue with 5.5 and 5.6

### DIFF
--- a/assets/src/block-editor/blocks/image/edit.js
+++ b/assets/src/block-editor/blocks/image/edit.js
@@ -287,7 +287,7 @@ const ImageEdit = ( {
 		return (
 			<>
 				{ controls }
-				<Block.figure>
+				<Block.figure ref={ ref }>
 					<Placeholder
 						icon={ icon }
 						label={ __( 'Unsplash', 'unsplash' ) }


### PR DESCRIPTION
## Summary

After the experimental Block.* component was deprecate in https://github.com/WordPress/gutenberg/pull/25515, this meant it generated an error on preview. This is because it *needs* ref to be passed. 

<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
