### PR TITLE
Hot fix for WordPress 5.8

### DIFF
--- a/assets/src/media-selector/style.css
+++ b/assets/src/media-selector/style.css
@@ -76,6 +76,15 @@
 	right: 300px;
 	left: 20px;
 	padding: 0;
+	overflow: auto;
+	bottom: 0;
+	outline: 0;
+}
+
+.unsplash-infinate-scroll .media-frame .unsplash-browser .unsplash-error,
+.unsplash-infinate-scroll .media-frame .unsplash-browser .no-media,
+.unsplash-infinate-scroll .media-frame .unsplash-browser .attachments {
+	right: 315px;
 }
 
 .media-frame .unsplash-browser .unsplash-error {
@@ -120,12 +129,15 @@
 
 @media only screen and (max-width: 900px) {
 
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .unsplash-error,
 	.media-frame .unsplash-browser .unsplash-error {
 		right: 282px;
 	}
 
 	.media-frame .unsplash-browser .no-media,
-	.media-frame .unsplash-browser .attachments {
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .no-media,
+	.media-frame .unsplash-browser .attachments,
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .attachments{
 		right: 262px;
 		top: 120px;
 	}
@@ -133,6 +145,7 @@
 
 @media only screen and (max-width: 640px), screen and (max-height: 400px) {
 
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .unsplash-error,
 	.media-frame .unsplash-browser .unsplash-error {
 		right: 20px;
 	}
@@ -140,6 +153,12 @@
 	.media-frame .unsplash-browser .no-media,
 	.media-frame .unsplash-browser .attachments {
 		right: 0;
+		top: 120px;
+	}
+
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .no-media,
+	.unsplash-infinate-scroll .media-frame .unsplash-browser .attachments{
+		right: 20px;
 		top: 120px;
 	}
 }

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -80,6 +80,8 @@ class Plugin extends Plugin_Base {
 		add_action( 'print_media_templates', [ $this, 'add_media_templates' ] );
 
 		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'add_unsplash_author_meta' ], 10, 2 );
+		add_filter( 'media_library_infinite_scrolling', '__return_true' );
+		add_filter( 'admin_body_class', [ $this, 'admin_body_class'] );
 	}
 
 	/**
@@ -130,6 +132,21 @@ class Plugin extends Plugin_Base {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Add a new class after WP 5.8 for different styles.
+	 *
+	 * @param string $classes Space-separated list of CSS classes.
+	 *
+	 * @return string
+	 */
+	public function admin_body_class( $classes ) {
+		if ( version_compare( '5.8', get_bloginfo( 'version' ), '>=' ) ) {
+			$classes .= ' unsplash-infinate-scroll';
+		}
+
+		return $classes;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Tweaks to media library selector, after changed in WordPress 5.8.

Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
