### PR TITLE
Add class name to figure tags

### DIFF
--- a/assets/src/block-editor/blocks/image/edit.js
+++ b/assets/src/block-editor/blocks/image/edit.js
@@ -283,11 +283,17 @@ const ImageEdit = ( {
 		imageHeight,
 	} = useImageSize( ref, url, [ align ] );
 
+	const classes = classnames( className, 'wp-block-image wp-block-unsplash wp-block', {
+		'is-resized': !! width || !! height,
+		'is-focused': isSelected,
+		[ `size-${ sizeSlug }` ]: sizeSlug,
+	} );
+
 	if ( ! url ) {
 		return (
 			<>
 				{ controls }
-				<Block.figure ref={ ref }>
+				<Block.figure ref={ ref } className={ classes }>
 					<Placeholder
 						icon={ icon }
 						label={ __( 'Unsplash', 'unsplash' ) }
@@ -322,12 +328,6 @@ const ImageEdit = ( {
 			/>
 		);
 	}
-
-	const classes = classnames( className, 'wp-block-image', {
-		'is-resized': !! width || !! height,
-		'is-focused': isSelected,
-		[ `size-${ sizeSlug }` ]: sizeSlug,
-	} );
 
 	const isResizable = ! isWideAligned && isLargeViewport;
 	const imageSizeOptions = getImageSizeOptions();


### PR DESCRIPTION
## Summary

Some more fixes for 5.8. 

#### Before

<img width="1324" alt="Screenshot 2021-09-07 at 00 49 13" src="https://user-images.githubusercontent.com/237508/132266232-caf822a9-b4ae-4b36-86da-a36ec436701f.png">


#### After  

<img width="1324" alt="Screenshot 2021-09-07 at 00 48 38" src="https://user-images.githubusercontent.com/237508/132266228-8e76d978-c0ed-41c7-9418-63e2e34baa25.png">

Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/unsplash-wp/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/xwp/unsplash-wp/blob/develop/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/unsplash-wp/blob/develop/contributing.md) (updates are often made to the guidelines, check it out periodically).
